### PR TITLE
feat: Add binary name for docker compile load

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,4 +1,4 @@
 FROM alpine:latest
 
-COPY kegistry /usr/bin/
-ENTRYPOINT ["kegistry"]
+COPY kerranamodb /usr/bin/
+ENTRYPOINT ["kerranamodb"]

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -16,7 +16,7 @@ type MetricName string
 type MetricLabel string
 
 const (
-	metricNamespace = "kegistry"
+	metricNamespace = "kerranamodb"
 
 	// Metrics
 	metricNameHTTPRequestTotal MetricName = "registry_request_total"


### PR DESCRIPTION
## WHY

Because the build  release execution https://github.com/kerraform/kerranamodb/actions/runs/3579771407/jobs/6021285413 failed 

> ERROR: failed to solve: failed to compute cache key: "/kegistry" not found: not found